### PR TITLE
Less GC when reading floats and doubles thanks to a pool of byte[] + Removed a unnecessary array creation and destruction

### DIFF
--- a/Lidgren.Network/NetBuffer.Read.cs
+++ b/Lidgren.Network/NetBuffer.Read.cs
@@ -18,7 +18,7 @@ namespace Lidgren.Network
 	{
 		private const string c_readOverflowError = "Trying to read past the buffer size - likely caused by mismatching Write/Reads, different size or order.";
 		private const int c_bufferSize = 64; // Min 8 to hold anything but strings. Increase it if readed strings usally don't fit inside the buffer
-		private static byte[] s_buffer;
+		private static object s_buffer;
 
 		/// <summary>
 		/// Reads a boolean value (stored as a single bit) written using Write(bool)
@@ -355,7 +355,7 @@ namespace Lidgren.Network
 				return retval;
 			}
 
-			byte[] bytes = Interlocked.Exchange(ref s_buffer, null) ?? new byte[c_bufferSize];
+			byte[] bytes = (byte[]) Interlocked.Exchange(ref s_buffer, null) ?? new byte[c_bufferSize];
 			ReadBytes(bytes, 0, 4);
 			float res = BitConverter.ToSingle(bytes, 0);
 			s_buffer = bytes;
@@ -380,7 +380,7 @@ namespace Lidgren.Network
 				return true;
 			}
 
-			byte[] bytes = Interlocked.Exchange(ref s_buffer, null) ?? new byte[c_bufferSize];
+			byte[] bytes = (byte[]) Interlocked.Exchange(ref s_buffer, null) ?? new byte[c_bufferSize];
 			ReadBytes(bytes, 0, 4);
 			result = BitConverter.ToSingle(bytes, 0);
 			s_buffer = bytes;
@@ -402,7 +402,7 @@ namespace Lidgren.Network
 				return retval;
 			}
 
-			byte[] bytes = Interlocked.Exchange(ref s_buffer, null) ?? new byte[c_bufferSize];
+			byte[] bytes = (byte[]) Interlocked.Exchange(ref s_buffer, null) ?? new byte[c_bufferSize];
 			ReadBytes(bytes, 0, 8);
 			double res = BitConverter.ToDouble(bytes, 0);
 			s_buffer = bytes;
@@ -605,7 +605,7 @@ namespace Lidgren.Network
 			}
 
 			if (byteLen <= c_bufferSize) {
-				byte[] buffer = Interlocked.Exchange(ref s_buffer, null) ?? new byte[c_bufferSize];
+				byte[] buffer = (byte[]) Interlocked.Exchange(ref s_buffer, null) ?? new byte[c_bufferSize];
 				ReadBytes(buffer, 0, byteLen);
 				string retval = Encoding.UTF8.GetString(buffer, 0, byteLen);
 				s_buffer = buffer;

--- a/Lidgren.Network/NetBuffer.Read.cs
+++ b/Lidgren.Network/NetBuffer.Read.cs
@@ -17,7 +17,7 @@ namespace Lidgren.Network
 	public partial class NetBuffer
 	{
 		private const string c_readOverflowError = "Trying to read past the buffer size - likely caused by mismatching Write/Reads, different size or order.";
-
+		private const int c_bufferSize = 64; // Min 8 to hold anything but strings. Increase it if readed strings usally don't fit inside the buffer
 		private static byte[] s_buffer;
 
 		/// <summary>
@@ -355,7 +355,7 @@ namespace Lidgren.Network
 				return retval;
 			}
 
-			byte[] bytes = Interlocked.Exchange(ref s_buffer, null) ?? new byte[8];
+			byte[] bytes = Interlocked.Exchange(ref s_buffer, null) ?? new byte[c_bufferSize];
 			ReadBytes(bytes, 0, 4);
 			float res = BitConverter.ToSingle(bytes, 0);
 			s_buffer = bytes;
@@ -380,7 +380,7 @@ namespace Lidgren.Network
 				return true;
 			}
 
-			byte[] bytes = Interlocked.Exchange(ref s_buffer, null) ?? new byte[8];
+			byte[] bytes = Interlocked.Exchange(ref s_buffer, null) ?? new byte[c_bufferSize];
 			ReadBytes(bytes, 0, 4);
 			result = BitConverter.ToSingle(bytes, 0);
 			s_buffer = bytes;
@@ -402,7 +402,7 @@ namespace Lidgren.Network
 				return retval;
 			}
 
-			byte[] bytes = Interlocked.Exchange(ref s_buffer, null) ?? new byte[8];
+			byte[] bytes = Interlocked.Exchange(ref s_buffer, null) ?? new byte[c_bufferSize];
 			ReadBytes(bytes, 0, 8);
 			double res = BitConverter.ToDouble(bytes, 0);
 			s_buffer = bytes;
@@ -604,8 +604,16 @@ namespace Lidgren.Network
 				return retval;
 			}
 
-			byte[] bytes = ReadBytes(byteLen);
-			return System.Text.Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+			if (byteLen <= c_bufferSize) {
+				byte[] buffer = Interlocked.Exchange(ref s_buffer, null) ?? new byte[c_bufferSize];
+				ReadBytes(buffer, 0, byteLen);
+				string retval = Encoding.UTF8.GetString(buffer, 0, byteLen);
+				s_buffer = buffer;
+				return retval;
+			} else {
+				byte[] bytes = ReadBytes(byteLen);
+				return Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+			}
 		}
 
 		/// <summary>

--- a/Lidgren.Network/NetServer.cs
+++ b/Lidgren.Network/NetServer.cs
@@ -24,7 +24,8 @@ namespace Lidgren.Network
 		/// <param name="method">How to deliver the message</param>
 		public void SendToAll(NetOutgoingMessage msg, NetDeliveryMethod method)
 		{
-			var all = this.Connections;
+			// Modifying m_connections will modify the list of the connections of the NetPeer. Do only reads here
+			var all = m_connections;
 			if (all.Count <= 0) {
 				if (msg.m_isSent == false)
 					Recycle(msg);
@@ -43,7 +44,8 @@ namespace Lidgren.Network
 		/// <param name="sequenceChannel">Which sequence channel to use for the message</param>
 		public void SendToAll(NetOutgoingMessage msg, NetConnection except, NetDeliveryMethod method, int sequenceChannel)
 		{
-			var all = this.Connections;
+			// Modifying m_connections will modify the list of the connections of the NetPeer. Do only reads here
+			var all = m_connections;
 			if (all.Count <= 0) {
 				if (msg.m_isSent == false)
 					Recycle(msg);


### PR DESCRIPTION
Pull request created after a [petition from @RevoluPowered](https://github.com/lidgren/lidgren-network-gen3/pull/70#issuecomment-343508858). I hope it helps

I was having a little issue with some kilobytes of gc because I was reading floats that where displaced (not byte aligned) in the buffer.

[See @Inverness comment](https://github.com/lidgren/lidgren-network-gen3/pull/70#issuecomment-228561416)

Readstring will generate garbage only if it doesn't fit on the saved buffer

The removed unnecessary array creation+destruction is due to the array being only readed inside an internal method, so no copies of it are needed